### PR TITLE
Add Revo MCP server for Esperanto dictionary lookup

### DIFF
--- a/revo-mcp/.gitignore
+++ b/revo-mcp/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+data/revo.db
+*.zip

--- a/revo-mcp/README.md
+++ b/revo-mcp/README.md
@@ -1,0 +1,144 @@
+# Revo MCP Server
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for looking up words in [Reta Vortaro](https://www.reta-vortaro.de/revo/) — the comprehensive, open-source Esperanto dictionary.
+
+Provides Esperanto definitions, examples, and translations across 174 languages to any MCP-compatible AI assistant (Claude Desktop, `claude` CLI, etc.).
+
+## Features
+
+- **Esperanto headword lookup** — definitions in Esperanto with example sentences
+- **Translation lookup** — search in English, German, French, or any of 174 languages
+- **Cross-language search** — find words across all available languages at once
+- **X-system support** — type `cxirkaux` instead of `ĉirkaŭ`
+- **Grammatical form stemming** — `amikojn` (plural accusative) automatically finds `amiko`
+- **Cross-references** — related words, synonyms, antonyms
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) 1.0+
+
+## Setup
+
+```bash
+cd revo-mcp
+
+# Install dependencies
+bun install
+
+# Download the Revo dictionary database (~43 MB download, ~280 MB extracted)
+# and create search indexes
+bun run setup
+```
+
+The setup script downloads the latest daily release of `revo.db` from [revuloj/revo-fonto releases](https://github.com/revuloj/revo-fonto/releases) and augments it with FTS5 full-text search indexes.
+
+## Usage
+
+### With Claude Desktop
+
+Add to your Claude Desktop MCP configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "revo": {
+      "command": "bun",
+      "args": ["run", "/absolute/path/to/revo-mcp/src/index.ts"]
+    }
+  }
+}
+```
+
+### With `claude` CLI
+
+Add to your MCP settings (`.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "revo": {
+      "command": "bun",
+      "args": ["run", "/absolute/path/to/revo-mcp/src/index.ts"]
+    }
+  }
+}
+```
+
+### Direct start
+
+```bash
+bun run start
+```
+
+The server communicates via stdio using the MCP protocol.
+
+## MCP Tools
+
+### `lookup`
+
+Search the Esperanto dictionary.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | (required) | Word to look up |
+| `lang` | string | `"eo"` | `"eo"` for Esperanto, `"en"`/`"de"`/`"fr"`/etc. for translations, `"all"` for any language |
+| `show_languages` | string[] | `["en","de","fr","es","ru","zh","ja"]` | Which translation languages to display |
+| `limit` | number | `5` | Max results (1-20) |
+
+**Examples:**
+
+- Look up an Esperanto word: `lookup({ query: "amiko" })`
+- Find English translation: `lookup({ query: "friend", lang: "en" })`
+- Search German: `lookup({ query: "Hund", lang: "de" })`
+- X-system input: `lookup({ query: "cxirkaux" })`
+- Inflected form: `lookup({ query: "amikojn" })`
+- Cross-language: `lookup({ query: "друг", lang: "all" })`
+
+### `languages`
+
+Lists all 174 available languages with translation counts. Takes no parameters.
+
+## Testing
+
+```bash
+# Run all tests (requires revo.db — run `bun run setup` first)
+bun test
+```
+
+The test suite includes:
+- Unit tests for the Esperanto stemmer and HTML extraction
+- Integration tests for the database query layer
+- 100 real-world usage scenarios covering beginner learners, advanced users, x-system input, stemming, multi-language search, and edge cases
+
+## Architecture
+
+```
+revo-mcp/
+├── src/
+│   ├── index.ts           # MCP server entry point (stdio transport)
+│   ├── db.ts              # SQLite queries (headword, translation, FTS search)
+│   ├── setup.ts           # Database download and FTS index creation
+│   ├── stemmer.ts         # Esperanto stemmer, x-system, normalization
+│   ├── html-extract.ts    # Extract definitions/examples from article HTML
+│   ├── formatter.ts       # Format results as Markdown
+│   └── tools/
+│       ├── lookup.ts      # lookup tool handler
+│       └── languages.ts   # languages tool handler
+├── test/
+│   ├── stemmer.test.ts
+│   ├── html-extract.test.ts
+│   ├── lookup.test.ts
+│   └── scenarios.test.ts  # 100 usage scenarios
+└── data/
+    └── revo.db            # Downloaded database (gitignored)
+```
+
+The server uses the pre-built SQLite database from the Revo daily releases, which contains:
+- 48,000+ headword entries
+- 801,000+ translations across 174 languages
+- 13,000+ full article definitions as HTML
+- Cross-references, usage domains, and variant spellings
+
+## License
+
+The Reta Vortaro dictionary content is licensed under the [GNU General Public License](https://www.gnu.org/licenses/gpl-3.0.html).

--- a/revo-mcp/bun.lock
+++ b/revo-mcp/bun.lock
@@ -1,0 +1,230 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "revo-mcp",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "node-html-parser": "^7.0.1",
+        "zod": "^3.25.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.0",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
+    "@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
+    "hono": ["hono@4.12.3", "", {}, "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-html-parser": ["node-html-parser@7.0.2", "", { "dependencies": { "css-select": "^5.1.0", "he": "1.2.0" } }, "sha512-DxodLVh7a6JMkYzWyc8nBX9MaF4M0lLFYkJHlWOiu7+9/I6mwNK9u5TbAMC7qfqDJEPX9OIoWA2A9t4C2l1mUQ=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+  }
+}

--- a/revo-mcp/package.json
+++ b/revo-mcp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "revo-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for Reta Vortaro (Esperanto dictionary) lookup",
+  "type": "module",
+  "scripts": {
+    "setup": "bun run src/setup.ts",
+    "start": "bun run src/index.ts",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "node-html-parser": "^7.0.1",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.0"
+  }
+}

--- a/revo-mcp/src/db.ts
+++ b/revo-mcp/src/db.ts
@@ -1,0 +1,444 @@
+/**
+ * Database connection and query functions for the Revo dictionary.
+ *
+ * Queries the pre-built revo.db (augmented with FTS5 indexes by setup.ts).
+ * Supports:
+ * - Esperanto headword lookup (exact, prefix, stemmed, FTS)
+ * - Translation lookup by language (exact, FTS)
+ * - Cross-language search
+ */
+
+import { Database } from "bun:sqlite";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { generateStems, normalizeQuery, fromXSystem, hasXSystem } from "./stemmer";
+import { extractArticle, extractByMrk, type DrvEntry } from "./html-extract";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DB_PATH = join(__dirname, "..", "data", "revo.db");
+
+export interface NodoRow {
+  mrk: string;
+  art: string;
+  kap: string;
+  num: string | null;
+}
+
+export interface TradukoRow {
+  mrk: string;
+  lng: string;
+  trd: string;
+  txt: string | null;
+}
+
+export interface LookupResult {
+  headword: string;
+  article: string;
+  mrk: string;
+  senses: {
+    num?: string;
+    definition: string;
+    examples: string[];
+    domain?: string;
+  }[];
+  translations: { lng: string; trd: string }[];
+  crossRefs: { target: string; type: string; targetKap?: string }[];
+  usageDomains: string[];
+  matchedVia?: string; // How the result was found (e.g., "stem:amik", "translation:en:friend")
+}
+
+let _db: Database | null = null;
+
+export function getDb(): Database {
+  if (!_db) {
+    _db = new Database(DB_PATH, { readonly: true });
+    _db.exec("PRAGMA cache_size = -64000"); // 64MB cache
+  }
+  return _db;
+}
+
+export function closeDb(): void {
+  if (_db) {
+    _db.close();
+    _db = null;
+  }
+}
+
+/**
+ * Look up an Esperanto word. Tries in order:
+ * 1. Exact match on nodo.kap
+ * 2. Variant match on var.kap
+ * 3. Stemmed matches (strip grammatical endings)
+ * 4. FTS5 prefix search
+ */
+export function lookupEsperanto(
+  query: string,
+  limit: number = 5
+): LookupResult[] {
+  const db = getDb();
+  let normalized = normalizeQuery(query);
+
+  if (normalized.length === 0) return [];
+
+  // 1. Exact match
+  let nodes = db
+    .query<NodoRow, [string]>(
+      "SELECT DISTINCT mrk, art, kap, num FROM nodo WHERE lower(kap) = ? ORDER BY length(mrk)"
+    )
+    .all(normalized);
+
+  if (nodes.length > 0) {
+    return assembleResults(nodes, limit);
+  }
+
+  // 2. Variant match
+  const variants = db
+    .query<{ mrk: string; kap: string }, [string]>(
+      "SELECT mrk, kap FROM var WHERE lower(kap) = ?"
+    )
+    .all(normalized);
+
+  if (variants.length > 0) {
+    const mrks = variants.map((v) => v.mrk);
+    nodes = db
+      .query<NodoRow, []>(
+        `SELECT DISTINCT mrk, art, kap, num FROM nodo WHERE mrk IN (${mrks
+          .map(() => "?")
+          .join(",")}) ORDER BY length(mrk)`
+      )
+      .all(...(mrks as []));
+
+    if (nodes.length > 0) {
+      return assembleResults(nodes, limit);
+    }
+  }
+
+  // 3. Stemmed matches
+  const stems = generateStems(normalized);
+  for (const stem of stems) {
+    if (stem === normalized) continue; // Already tried
+    nodes = db
+      .query<NodoRow, [string]>(
+        "SELECT DISTINCT mrk, art, kap, num FROM nodo WHERE lower(kap) = ? ORDER BY length(mrk)"
+      )
+      .all(stem);
+
+    if (nodes.length > 0) {
+      const results = assembleResults(nodes, limit);
+      for (const r of results) r.matchedVia = `stem:${stem}`;
+      return results;
+    }
+  }
+
+  // 4. Prefix match
+  nodes = db
+    .query<NodoRow, [string, number]>(
+      "SELECT DISTINCT mrk, art, kap, num FROM nodo WHERE lower(kap) LIKE ? || '%' ORDER BY length(kap), kap LIMIT ?"
+    )
+    .all(normalized, limit * 5);
+
+  if (nodes.length > 0) {
+    const results = assembleResults(nodes, limit);
+    for (const r of results) r.matchedVia = `prefix:${normalized}`;
+    return results;
+  }
+
+  // 5. FTS5 fallback
+  try {
+    const ftsRows = db
+      .query<{ kap: string; rowid: number }, [string]>(
+        `SELECT kap, rowid FROM fts_kap WHERE kap MATCH ? || '*' LIMIT ?`
+      )
+      .all(normalized);
+
+    if (ftsRows.length > 0) {
+      const kaps = [...new Set(ftsRows.map((r) => r.kap.toLowerCase()))];
+      const allNodes: NodoRow[] = [];
+      for (const kap of kaps.slice(0, limit)) {
+        const n = db
+          .query<NodoRow, [string]>(
+            "SELECT DISTINCT mrk, art, kap, num FROM nodo WHERE lower(kap) = ? ORDER BY length(mrk)"
+          )
+          .all(kap);
+        allNodes.push(...n);
+      }
+      if (allNodes.length > 0) {
+        const results = assembleResults(allNodes, limit);
+        for (const r of results) r.matchedVia = `fts:${normalized}`;
+        return results;
+      }
+    }
+  } catch {
+    // FTS query might fail with special characters — ignore
+  }
+
+  return [];
+}
+
+/**
+ * Look up a word in a specific translation language.
+ */
+export function lookupTranslation(
+  query: string,
+  lang: string,
+  limit: number = 5
+): LookupResult[] {
+  const db = getDb();
+  const normalized = query.trim().toLowerCase();
+
+  if (normalized.length === 0) return [];
+
+  // 1. Exact match
+  let trds = db
+    .query<TradukoRow, [string, string]>(
+      "SELECT mrk, lng, trd, txt FROM traduko WHERE lng = ? AND lower(trd) = ? LIMIT 50"
+    )
+    .all(lang, normalized);
+
+  if (trds.length === 0) {
+    // 2. FTS match
+    try {
+      const ftsRows = db
+        .query<{ trd: string; rowid: number }, [string]>(
+          `SELECT trd, rowid FROM fts_trd WHERE trd MATCH '"' || ? || '"' LIMIT 100`
+        )
+        .all(normalized);
+
+      // Filter by language using the traduko table
+      if (ftsRows.length > 0) {
+        const rowids = ftsRows.map((r) => r.rowid);
+        // Get matching traduko rows filtered by language
+        for (const rowid of rowids) {
+          const row = db
+            .query<TradukoRow, [number, string]>(
+              "SELECT mrk, lng, trd, txt FROM traduko WHERE rowid = ? AND lng = ?"
+            )
+            .get(rowid, lang);
+          if (row) trds.push(row);
+        }
+      }
+    } catch {
+      // FTS query might fail — ignore
+    }
+  }
+
+  if (trds.length === 0) {
+    // 3. LIKE partial match
+    trds = db
+      .query<TradukoRow, [string, string]>(
+        "SELECT mrk, lng, trd, txt FROM traduko WHERE lng = ? AND lower(trd) LIKE '%' || ? || '%' LIMIT 50"
+      )
+      .all(lang, normalized);
+  }
+
+  if (trds.length === 0) return [];
+
+  // Get unique mrk values and look up the nodes
+  const uniqueMrks = [...new Set(trds.map((t) => t.mrk))];
+  const allNodes: NodoRow[] = [];
+  for (const mrk of uniqueMrks.slice(0, limit * 3)) {
+    const node = db
+      .query<NodoRow, [string]>(
+        "SELECT mrk, art, kap, num FROM nodo WHERE mrk = ?"
+      )
+      .get(mrk);
+    if (node) allNodes.push(node);
+  }
+
+  const results = assembleResults(allNodes, limit);
+  for (const r of results) {
+    const matched = trds.find((t) => t.mrk === r.mrk);
+    r.matchedVia = `translation:${lang}:${matched?.trd ?? query}`;
+  }
+  return results;
+}
+
+/**
+ * Look up a word across all languages.
+ */
+export function lookupAllLanguages(
+  query: string,
+  limit: number = 5
+): LookupResult[] {
+  const db = getDb();
+  const normalized = query.trim().toLowerCase();
+
+  // Also try as Esperanto headword
+  const eoResults = lookupEsperanto(query, limit);
+
+  // Search translations across all languages
+  let trds = db
+    .query<TradukoRow, [string]>(
+      "SELECT mrk, lng, trd, txt FROM traduko WHERE lower(trd) = ? LIMIT 100"
+    )
+    .all(normalized);
+
+  if (trds.length === 0) {
+    // FTS fallback
+    try {
+      trds = db
+        .query<TradukoRow, [string]>(
+          `SELECT t.mrk, t.lng, t.trd, t.txt
+           FROM fts_trd f
+           JOIN traduko t ON f.rowid = t.rowid
+           WHERE f.trd MATCH '"' || ? || '"'
+           LIMIT 100`
+        )
+        .all(normalized);
+    } catch {
+      // ignore FTS errors
+    }
+  }
+
+  const uniqueMrks = [...new Set(trds.map((t) => t.mrk))];
+  const allNodes: NodoRow[] = [];
+  for (const mrk of uniqueMrks.slice(0, limit * 3)) {
+    const node = db
+      .query<NodoRow, [string]>(
+        "SELECT mrk, art, kap, num FROM nodo WHERE mrk = ?"
+      )
+      .get(mrk);
+    if (node) allNodes.push(node);
+  }
+
+  const trdResults = assembleResults(allNodes, limit);
+  for (const r of trdResults) {
+    const matched = trds.find((t) => t.mrk === r.mrk);
+    r.matchedVia = `translation:${matched?.lng ?? "?"}:${matched?.trd ?? query}`;
+  }
+
+  // Merge eo results + translation results, dedup by mrk
+  const seen = new Set<string>();
+  const merged: LookupResult[] = [];
+  for (const r of [...eoResults, ...trdResults]) {
+    if (!seen.has(r.mrk)) {
+      seen.add(r.mrk);
+      merged.push(r);
+    }
+  }
+  return merged.slice(0, limit);
+}
+
+/**
+ * Assemble full lookup results from matched nodo rows.
+ * Groups by article, fetches definitions from HTML, translations, etc.
+ */
+function assembleResults(
+  nodes: NodoRow[],
+  limit: number
+): LookupResult[] {
+  const db = getDb();
+  const results: LookupResult[] = [];
+
+  // Group by derivation-level mrk (no dot-dot in mrk, or first two segments)
+  const drvNodes = new Map<string, NodoRow>();
+  for (const node of nodes) {
+    const drvMrk = getDrvMrk(node.mrk);
+    if (!drvNodes.has(drvMrk)) {
+      drvNodes.set(drvMrk, node);
+    }
+  }
+
+  for (const [drvMrk, node] of drvNodes) {
+    if (results.length >= limit) break;
+
+    // Fetch article HTML
+    const artRow = db
+      .query<{ txt: Buffer }, [string]>(
+        "SELECT txt FROM artikolo WHERE mrk = ?"
+      )
+      .get(node.art);
+
+    let senses: LookupResult["senses"] = [];
+    if (artRow?.txt) {
+      const entry = extractByMrk(artRow.txt, drvMrk);
+      if (entry) {
+        senses = entry.senses;
+      }
+    }
+
+    // Fetch translations for this mrk
+    const translations = db
+      .query<{ lng: string; trd: string }, [string]>(
+        "SELECT lng, trd FROM traduko WHERE mrk = ? ORDER BY lng"
+      )
+      .all(drvMrk);
+
+    // Also fetch translations at sense level
+    const senseTranslations = db
+      .query<{ lng: string; trd: string; mrk: string }, [string]>(
+        "SELECT lng, trd, mrk FROM traduko WHERE mrk LIKE ? || '.%' ORDER BY lng"
+      )
+      .all(drvMrk);
+
+    const allTranslations = [...translations, ...senseTranslations].map(
+      (t) => ({
+        lng: t.lng,
+        trd: t.trd,
+      })
+    );
+
+    // Fetch cross-references
+    const refs = db
+      .query<{ cel: string; tip: string }, [string]>(
+        "SELECT cel, tip FROM referenco WHERE mrk = ? OR mrk LIKE ? || '.%'"
+      )
+      .all(drvMrk, drvMrk);
+
+    const crossRefs = refs.map((r) => {
+      // Try to resolve target headword
+      const targetNode = db
+        .query<{ kap: string }, [string]>(
+          "SELECT kap FROM nodo WHERE mrk = ?"
+        )
+        .get(r.cel);
+      return {
+        target: r.cel,
+        type: r.tip,
+        targetKap: targetNode?.kap,
+      };
+    });
+
+    // Fetch usage domains
+    const uzoj = db
+      .query<{ uzo: string }, [string]>(
+        "SELECT DISTINCT uzo FROM uzo WHERE mrk = ? OR mrk LIKE ? || '.%'"
+      )
+      .all(drvMrk, drvMrk);
+    const usageDomains = uzoj.map((u) => u.uzo);
+
+    results.push({
+      headword: node.kap,
+      article: node.art,
+      mrk: drvMrk,
+      senses,
+      translations: allTranslations,
+      crossRefs,
+      usageDomains,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Extract the derivation-level mrk from a potentially sense-level mrk.
+ * E.g., "amik.0o.KOMUNE" → "amik.0o"
+ */
+function getDrvMrk(mrk: string): string {
+  const parts = mrk.split(".");
+  if (parts.length <= 2) return mrk;
+  return parts.slice(0, 2).join(".");
+}
+
+/**
+ * Get all available languages with their translation counts.
+ */
+export function getLanguages(): { lng: string; count: number }[] {
+  const db = getDb();
+  return db
+    .query<{ lng: string; count: number }, []>(
+      "SELECT lng, COUNT(*) as count FROM traduko GROUP BY lng ORDER BY count DESC"
+    )
+    .all();
+}

--- a/revo-mcp/src/formatter.ts
+++ b/revo-mcp/src/formatter.ts
@@ -1,0 +1,162 @@
+/**
+ * Formats lookup results as readable Markdown text for MCP tool responses.
+ */
+
+import type { LookupResult } from "./db";
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  af: "Afrikaans", am: "Amara", ar: "Araba", az: "Azerbajĝana",
+  be: "Belarusa", bg: "Bulgara", bn: "Bengala", bo: "Tibeta",
+  br: "Bretona", bs: "Bosnia", ca: "Kataluna", co: "Korsika",
+  cs: "Ĉeĥa", cy: "Kimra", da: "Dana", de: "Germana",
+  el: "Greka", en: "Angla", eo: "Esperanto", es: "Hispana",
+  et: "Estona", eu: "Eŭska", fa: "Persa", fi: "Finna",
+  fr: "Franca", fy: "Frisa", ga: "Irlanda", gd: "Gaela",
+  gl: "Galega", gu: "Guĝarata", ha: "Haŭsa", he: "Hebrea",
+  hi: "Hinda", hr: "Kroata", hu: "Hungara", hy: "Armena",
+  id: "Indonezia", is: "Islanda", it: "Itala", ja: "Japana",
+  jv: "Java", ka: "Kartvela", kk: "Kazaĥa", km: "Kmera",
+  kn: "Kanara", ko: "Korea", ku: "Kurda", ky: "Kirgiza",
+  la: "Latina", lb: "Luksemburga", lt: "Litova", lv: "Latva",
+  mg: "Malagasa", mk: "Makedona", ml: "Malajala", mn: "Mongola",
+  mr: "Marata", ms: "Malaja", mt: "Malta", my: "Birma",
+  ne: "Nepala", nl: "Nederlanda", no: "Norvega", oc: "Okcitana",
+  pa: "Panĝaba", pl: "Pola", ps: "Paŝtua", pt: "Portugala",
+  qu: "Keĉua", rm: "Romanĉa", ro: "Rumana", ru: "Rusa",
+  rw: "Ruanda", sa: "Sanskrita", sd: "Sinda", si: "Sinhala",
+  sk: "Slovaka", sl: "Slovena", so: "Somala", sq: "Albana",
+  sr: "Serba", sv: "Sveda", sw: "Svahila", ta: "Tamila",
+  te: "Telugua", tg: "Taĝika", th: "Taja", tk: "Turkmena",
+  tl: "Filipina", tr: "Turka", tt: "Tatara", ug: "Ujgura",
+  uk: "Ukraina", ur: "Urdua", uz: "Uzbeka", vi: "Vjetnama",
+  xh: "Ksosa", yi: "Jida", yo: "Joruba", zh: "Ĉina",
+  zu: "Zulua", sgn: "Signolingvo",
+};
+
+export function languageName(code: string): string {
+  return LANGUAGE_NAMES[code] ?? code;
+}
+
+/**
+ * Format a set of lookup results as markdown.
+ */
+export function formatResults(
+  results: LookupResult[],
+  showLanguages?: string[]
+): string {
+  if (results.length === 0) {
+    return "No results found.";
+  }
+
+  const parts: string[] = [];
+
+  for (const result of results) {
+    parts.push(formatSingleResult(result, showLanguages));
+  }
+
+  return parts.join("\n\n---\n\n");
+}
+
+function formatSingleResult(
+  result: LookupResult,
+  showLanguages?: string[]
+): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`## ${result.headword}`);
+  if (result.matchedVia) {
+    lines.push(`*Matched via: ${result.matchedVia}*`);
+  }
+
+  // Usage domains
+  if (result.usageDomains.length > 0) {
+    lines.push(`**Domain:** ${result.usageDomains.join(", ")}`);
+  }
+
+  // Definitions
+  if (result.senses.length > 0) {
+    lines.push("");
+    lines.push("### Definitions");
+    for (const sense of result.senses) {
+      const prefix = sense.num ? `**${sense.num}** ` : "";
+      const domain = sense.domain ? ` *(${sense.domain})*` : "";
+
+      if (sense.definition) {
+        lines.push(`${prefix}${sense.definition}${domain}`);
+      }
+
+      // Examples
+      if (sense.examples.length > 0) {
+        for (const ex of sense.examples.slice(0, 3)) {
+          lines.push(`  - *${ex}*`);
+        }
+        if (sense.examples.length > 3) {
+          lines.push(`  - *(${sense.examples.length - 3} more examples...)*`);
+        }
+      }
+      lines.push("");
+    }
+  }
+
+  // Translations
+  const translations = filterTranslations(result.translations, showLanguages);
+  if (translations.length > 0) {
+    lines.push("### Translations");
+    // Group by language
+    const byLang = new Map<string, string[]>();
+    for (const t of translations) {
+      const existing = byLang.get(t.lng) ?? [];
+      existing.push(t.trd);
+      byLang.set(t.lng, existing);
+    }
+
+    for (const [lng, trds] of byLang) {
+      const uniqueTrds = [...new Set(trds)];
+      const name = languageName(lng);
+      lines.push(`- **${name}** (${lng}): ${uniqueTrds.join(", ")}`);
+    }
+  }
+
+  // Cross-references
+  const meaningfulRefs = result.crossRefs.filter(
+    (r) => r.targetKap && r.type !== "super"
+  );
+  if (meaningfulRefs.length > 0) {
+    lines.push("");
+    lines.push("### See also");
+    for (const ref of meaningfulRefs.slice(0, 5)) {
+      const typeLabel = refTypeLabel(ref.type);
+      lines.push(`- ${typeLabel}: ${ref.targetKap}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function filterTranslations(
+  translations: { lng: string; trd: string }[],
+  showLanguages?: string[]
+): { lng: string; trd: string }[] {
+  if (!showLanguages || showLanguages.length === 0) {
+    // Show a default set of common languages
+    const defaultLangs = ["en", "de", "fr", "es", "ru", "zh", "ja"];
+    return translations.filter((t) => defaultLangs.includes(t.lng));
+  }
+  return translations.filter((t) => showLanguages.includes(t.lng));
+}
+
+function refTypeLabel(type: string): string {
+  switch (type) {
+    case "vid": return "See";
+    case "sin": return "Synonym";
+    case "ant": return "Antonym";
+    case "dif": return "Differs from";
+    case "super": return "Broader";
+    case "sub": return "Narrower";
+    case "prt": return "Part of";
+    case "hom": return "Homonym";
+    case "malprt": return "Contains";
+    default: return type;
+  }
+}

--- a/revo-mcp/src/html-extract.ts
+++ b/revo-mcp/src/html-extract.ts
@@ -1,0 +1,195 @@
+/**
+ * Extracts structured definition and example data from the HTML article blobs
+ * stored in the `artikolo` table of the Revo database.
+ *
+ * The HTML is machine-generated with consistent CSS classes:
+ * - <section class="drv"> — derivation sections
+ * - <h2 id="mrk"> — derivation headword (ID = nodo.mrk)
+ * - <dt id="mrk.sense">N.</dt> — sense number
+ * - <span class="dif"> — definition text
+ * - <i class="ekz"> — example sentences
+ * - <span class="ekztld"> — root word placeholder in examples
+ * - <span class="fntref"> — bibliographic references (to strip)
+ * - <span class="klr"> — clarifications
+ */
+
+import { parse, HTMLElement, TextNode } from "node-html-parser";
+
+export interface DrvEntry {
+  mrk: string;
+  headword: string;
+  senses: SenseEntry[];
+}
+
+export interface SenseEntry {
+  mrk?: string;
+  num?: string;
+  definition: string;
+  examples: string[];
+  domain?: string;
+}
+
+/**
+ * Extract all derivation entries from an article HTML blob.
+ */
+export function extractArticle(htmlBlob: Buffer | Uint8Array): DrvEntry[] {
+  const html = Buffer.from(htmlBlob).toString("utf-8");
+  const root = parse(html);
+  const entries: DrvEntry[] = [];
+
+  const drvSections = root.querySelectorAll("section.drv");
+
+  for (const drv of drvSections) {
+    const h2 = drv.querySelector("h2");
+    if (!h2) continue;
+
+    const mrk = h2.getAttribute("id") ?? "";
+    const headword = cleanText(h2.text);
+
+    const senses = extractSenses(drv, mrk);
+    entries.push({ mrk, headword, senses });
+  }
+
+  return entries;
+}
+
+/**
+ * Extract a specific derivation entry by its mrk ID.
+ */
+export function extractByMrk(
+  htmlBlob: Buffer | Uint8Array,
+  targetMrk: string
+): DrvEntry | null {
+  const html = Buffer.from(htmlBlob).toString("utf-8");
+  const root = parse(html);
+
+  // Try to find the h2 with this exact ID (derivation level)
+  const h2 = root.querySelector(`h2[id="${targetMrk}"]`);
+  if (h2) {
+    const drv = h2.closest("section.drv");
+    if (drv) {
+      const headword = cleanText(h2.text);
+      const senses = extractSenses(drv, targetMrk);
+      return { mrk: targetMrk, headword, senses };
+    }
+  }
+
+  // Maybe it's a sense-level mrk — find the dt with this ID
+  const dt = root.querySelector(`dt[id="${targetMrk}"]`);
+  if (dt) {
+    const drv = dt.closest("section.drv");
+    const drvH2 = drv?.querySelector("h2");
+    if (drv && drvH2) {
+      const drvMrk = drvH2.getAttribute("id") ?? "";
+      const headword = cleanText(drvH2.text);
+      // Extract just the one sense
+      const dd = dt.nextElementSibling;
+      if (dd) {
+        const sense = extractSenseFromDd(dd, targetMrk, dt.text.trim());
+        return { mrk: drvMrk, headword, senses: [sense] };
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractSenses(drv: HTMLElement, drvMrk: string): SenseEntry[] {
+  const senses: SenseEntry[] = [];
+
+  // Only select <dt> elements that are NOT translation headings (class="lng")
+  // Definition <dt> elements have an id attribute or a numeric content like "1.", "2."
+  // Translation <dt> elements have class="lng" and contain language names like "angle:"
+  const dts = drv.querySelectorAll("dt");
+  const defDts = dts.filter(
+    (dt) => !dt.classNames.includes("lng")
+  );
+
+  if (defDts.length === 0) {
+    // No numbered senses — the whole drv is one definition
+    // Look for the first <dd> that's NOT a translation
+    const dd = drv.querySelector("dd");
+    if (dd && !dd.getAttribute("lang")) {
+      senses.push(extractSenseFromDd(dd, drvMrk));
+    } else {
+      // Try to get definition from the drv content directly
+      const dif = drv.querySelector("span.dif");
+      if (dif) {
+        senses.push({
+          mrk: drvMrk,
+          definition: cleanDefinition(dif),
+          examples: extractExamples(dif.parentNode as HTMLElement),
+        });
+      }
+    }
+    return senses;
+  }
+
+  for (const dt of defDts) {
+    const senseMrk = dt.getAttribute("id");
+    const num = dt.text.trim();
+    const dd = dt.nextElementSibling;
+    if (dd && dd.tagName === "DD") {
+      senses.push(extractSenseFromDd(dd, senseMrk ?? undefined, num));
+    }
+  }
+
+  return senses;
+}
+
+function extractSenseFromDd(
+  dd: HTMLElement,
+  mrk?: string,
+  num?: string
+): SenseEntry {
+  const dif = dd.querySelector("span.dif");
+  const definition = dif ? cleanDefinition(dif) : "";
+  const examples = extractExamples(dd);
+
+  // Check for usage domain
+  const uzo = dd.querySelector("abbr.uzo, span.uzo");
+  const domain = uzo ? uzo.text.trim() : undefined;
+
+  return { mrk, num, definition, examples, domain };
+}
+
+function extractExamples(container: HTMLElement): string[] {
+  const examples: string[] = [];
+  const ekzElements = container.querySelectorAll("i.ekz");
+
+  for (const ekz of ekzElements) {
+    // Clone to avoid mutating the original
+    const clone = parse(ekz.outerHTML);
+    // Remove bibliographic references
+    for (const ref of clone.querySelectorAll("span.fntref, sup.fntref")) {
+      ref.remove();
+    }
+    const text = cleanText(clone.text);
+    if (text.length > 0) {
+      examples.push(text);
+    }
+  }
+
+  return examples;
+}
+
+function cleanDefinition(dif: HTMLElement): string {
+  // Clone to remove refs without mutating
+  const clone = parse(dif.outerHTML);
+  // Remove bibliographic references
+  for (const ref of clone.querySelectorAll("span.fntref, sup.fntref")) {
+    ref.remove();
+  }
+  // Remove nested examples (they'll be extracted separately)
+  for (const ekz of clone.querySelectorAll("i.ekz")) {
+    ekz.remove();
+  }
+  return cleanText(clone.text);
+}
+
+/**
+ * Clean extracted text: collapse whitespace, trim.
+ */
+function cleanText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}

--- a/revo-mcp/src/index.ts
+++ b/revo-mcp/src/index.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env bun
+/**
+ * MCP server for Reta Vortaro (Esperanto dictionary).
+ *
+ * Provides lookup tools for Esperanto words, translations, and cross-language search.
+ * Uses the pre-built revo.db SQLite database (downloaded via `bun run setup`).
+ *
+ * Transport: stdio (for use with Claude Desktop, claude CLI, etc.)
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { lookupInputSchema, handleLookup } from "./tools/lookup";
+import { handleLanguages } from "./tools/languages";
+import { closeDb } from "./db";
+
+const server = new McpServer({
+  name: "revo-vortaro",
+  version: "1.0.0",
+});
+
+server.tool(
+  "lookup",
+  "Look up a word in the Reta Vortaro (Esperanto dictionary). " +
+    "Search Esperanto headwords (lang='eo'), translations in a specific language " +
+    "(lang='en'/'de'/'fr'/etc.), or across all 174 languages (lang='all'). " +
+    "Returns definitions (in Esperanto), examples, translations, and cross-references. " +
+    "Supports x-system input (e.g., 'cxirkaux' for 'ĉirkaŭ') and grammatical form stemming " +
+    "(e.g., 'amikojn' finds 'amiko').",
+  lookupInputSchema.shape,
+  async (args) => {
+    try {
+      const text = handleLookup(args as any);
+      return { content: [{ type: "text" as const, text }] };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text" as const, text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+server.tool(
+  "languages",
+  "List all available languages in the Reta Vortaro dictionary with their translation counts.",
+  {},
+  async () => {
+    try {
+      const text = handleLanguages();
+      return { content: [{ type: "text" as const, text }] };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text" as const, text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// Clean up on exit
+process.on("SIGINT", () => {
+  closeDb();
+  process.exit(0);
+});
+process.on("SIGTERM", () => {
+  closeDb();
+  process.exit(0);
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/revo-mcp/src/setup.ts
+++ b/revo-mcp/src/setup.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env bun
+/**
+ * Setup script: downloads the pre-built Revo SQLite database from GitHub releases
+ * and augments it with FTS5 indexes for fast lookup.
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = join(__dirname, "..", "data");
+const DB_PATH = join(DATA_DIR, "revo.db");
+const REPO = "revuloj/revo-fonto";
+
+async function getLatestReleaseDbUrl(): Promise<string> {
+  const resp = await fetch(
+    `https://api.github.com/repos/${REPO}/releases/latest`
+  );
+  if (!resp.ok) throw new Error(`GitHub API error: ${resp.status}`);
+  const data = (await resp.json()) as {
+    assets: { name: string; browser_download_url: string }[];
+  };
+  const asset = data.assets.find((a) => a.name.startsWith("revosql_") && a.name.endsWith(".zip"));
+  if (!asset) throw new Error("No revosql_*.zip found in latest release");
+  return asset.browser_download_url;
+}
+
+async function downloadAndExtract(url: string): Promise<void> {
+  console.log(`Downloading ${url}...`);
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`Download failed: ${resp.status}`);
+  const zipData = await resp.arrayBuffer();
+  const zipPath = join(DATA_DIR, "revosql.zip");
+  await Bun.write(zipPath, zipData);
+  console.log(`Downloaded ${(zipData.byteLength / 1024 / 1024).toFixed(1)} MB`);
+
+  console.log("Extracting...");
+  const proc = Bun.spawnSync(["unzip", "-o", zipPath, "-d", DATA_DIR]);
+  if (proc.exitCode !== 0) {
+    throw new Error(`unzip failed: ${proc.stderr.toString()}`);
+  }
+
+  // The zip contains revo.db
+  const extractedPath = join(DATA_DIR, "revo.db");
+  if (!existsSync(extractedPath)) {
+    throw new Error("revo.db not found after extraction");
+  }
+
+  // Clean up zip
+  await Bun.write(zipPath, ""); // truncate
+  const { unlinkSync } = await import("fs");
+  unlinkSync(zipPath);
+  console.log("Extracted revo.db");
+}
+
+function augmentWithIndexes(dbPath: string): void {
+  console.log("Augmenting database with FTS5 indexes...");
+  const db = new Database(dbPath);
+
+  // Standard indexes for common queries
+  db.run("CREATE INDEX IF NOT EXISTS idx_nodo_kap ON nodo(kap COLLATE NOCASE)");
+  db.run("CREATE INDEX IF NOT EXISTS idx_nodo_art ON nodo(art)");
+  db.run("CREATE INDEX IF NOT EXISTS idx_traduko_mrk ON traduko(mrk)");
+  db.run(
+    "CREATE INDEX IF NOT EXISTS idx_traduko_lng_trd ON traduko(lng, trd COLLATE NOCASE)"
+  );
+  db.run("CREATE INDEX IF NOT EXISTS idx_var_kap ON var(kap COLLATE NOCASE)");
+  db.run("CREATE INDEX IF NOT EXISTS idx_referenco_mrk ON referenco(mrk)");
+  db.run("CREATE INDEX IF NOT EXISTS idx_uzo_mrk ON uzo(mrk)");
+  console.log("  Standard indexes created.");
+
+  // FTS5 for headword search
+  const ftsKapExists = db
+    .query(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='fts_kap'"
+    )
+    .get();
+  if (!ftsKapExists) {
+    db.run(`
+      CREATE VIRTUAL TABLE fts_kap USING fts5(
+        kap,
+        tokenize='unicode61 remove_diacritics 2'
+      )
+    `);
+    db.run("INSERT INTO fts_kap(rowid, kap) SELECT rowid, kap FROM nodo");
+    // Include variant headwords
+    db.run(`
+      INSERT INTO fts_kap(kap)
+        SELECT v.kap FROM var v
+    `);
+    console.log("  FTS5 headword index created.");
+  } else {
+    console.log("  FTS5 headword index already exists.");
+  }
+
+  // FTS5 for translation search
+  const ftsTrdExists = db
+    .query(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='fts_trd'"
+    )
+    .get();
+  if (!ftsTrdExists) {
+    db.run(`
+      CREATE VIRTUAL TABLE fts_trd USING fts5(
+        trd,
+        tokenize='unicode61 remove_diacritics 2'
+      )
+    `);
+    db.run("INSERT INTO fts_trd(rowid, trd) SELECT rowid, trd FROM traduko");
+    console.log("  FTS5 translation index created.");
+  } else {
+    console.log("  FTS5 translation index already exists.");
+  }
+
+  db.close();
+  console.log("Database augmentation complete.");
+}
+
+async function main() {
+  mkdirSync(DATA_DIR, { recursive: true });
+
+  if (existsSync(DB_PATH)) {
+    console.log("revo.db already exists. Re-augmenting indexes...");
+  } else {
+    const url = await getLatestReleaseDbUrl();
+    await downloadAndExtract(url);
+  }
+
+  augmentWithIndexes(DB_PATH);
+  console.log("\nSetup complete! Run `bun run start` to start the MCP server.");
+}
+
+main().catch((err) => {
+  console.error("Setup failed:", err);
+  process.exit(1);
+});

--- a/revo-mcp/src/stemmer.ts
+++ b/revo-mcp/src/stemmer.ts
@@ -1,0 +1,140 @@
+/**
+ * Esperanto word stemmer and normalization utilities.
+ *
+ * Handles:
+ * - X-system conversion (cx→ĉ, gx→ĝ, etc.)
+ * - H-system conversion (ch→ĉ, gh→ĝ, etc.)
+ * - Grammatical ending stripping to find dictionary headwords
+ * - Case normalization
+ */
+
+const X_SYSTEM_MAP: Record<string, string> = {
+  cx: "ĉ",
+  gx: "ĝ",
+  hx: "ĥ",
+  jx: "ĵ",
+  sx: "ŝ",
+  ux: "ŭ",
+  Cx: "Ĉ",
+  Gx: "Ĝ",
+  Hx: "Ĥ",
+  Jx: "Ĵ",
+  Sx: "Ŝ",
+  Ux: "Ŭ",
+  CX: "Ĉ",
+  GX: "Ĝ",
+  HX: "Ĥ",
+  JX: "Ĵ",
+  SX: "Ŝ",
+  UX: "Ŭ",
+};
+
+// Sorted longest-first for correct greedy matching
+const X_SYSTEM_PATTERN = /[cCgGhHjJsSuU][xX]/g;
+
+/**
+ * Convert x-system text to proper Esperanto Unicode.
+ * E.g., "cxirkaux" → "ĉirkaŭ"
+ */
+export function fromXSystem(text: string): string {
+  return text.replace(X_SYSTEM_PATTERN, (match) => X_SYSTEM_MAP[match] ?? match);
+}
+
+/**
+ * Check if text contains x-system notation.
+ */
+export function hasXSystem(text: string): boolean {
+  return /[cCgGhHjJsSuU][xX]/.test(text);
+}
+
+/**
+ * Esperanto grammatical endings, ordered from longest to shortest
+ * for greedy stripping.
+ */
+const VERB_ENDINGS = ["anta", "inta", "onta", "ata", "ita", "ota"];
+const NOUN_ADJ_ENDINGS_LONG = ["ojn", "ajn"];
+const NOUN_ADJ_ENDINGS_MED = ["oj", "aj", "on", "an"];
+const VERB_TENSE_ENDINGS = ["as", "is", "os", "us"];
+const SHORT_ENDINGS = ["o", "a", "e", "i", "u", "n", "j"];
+
+/**
+ * Generate candidate stems from an Esperanto word by stripping grammatical endings.
+ *
+ * Returns candidates ordered from most-stripped (shortest) to original (longest).
+ * E.g., "amikojn" → ["amik", "amiko", "amikoj", "amikojn"]
+ *
+ * The idea: try the most reduced form first, since dictionary headwords
+ * are typically root+o (nouns), root+a (adjectives), root+i (verbs).
+ */
+export function generateStems(word: string): string[] {
+  const lower = word.toLowerCase();
+  const stems = new Set<string>();
+
+  // Always include the original word
+  stems.add(lower);
+
+  // Try stripping participal endings first (-anta, -inta, etc.)
+  for (const ending of VERB_ENDINGS) {
+    if (lower.endsWith(ending) && lower.length > ending.length + 2) {
+      const root = lower.slice(0, -ending.length);
+      stems.add(root + "i"); // verb infinitive
+      stems.add(root);
+    }
+  }
+
+  // Try stripping long compound endings (-ojn, -ajn)
+  for (const ending of NOUN_ADJ_ENDINGS_LONG) {
+    if (lower.endsWith(ending) && lower.length > ending.length + 2) {
+      const base = lower.slice(0, -ending.length);
+      stems.add(base);
+      stems.add(base + "o"); // noun form
+      stems.add(base + "a"); // adjective form
+    }
+  }
+
+  // Try stripping medium endings (-oj, -aj, -on, -an)
+  for (const ending of NOUN_ADJ_ENDINGS_MED) {
+    if (lower.endsWith(ending) && lower.length > ending.length + 2) {
+      const base = lower.slice(0, -ending.length);
+      stems.add(base);
+      stems.add(base + "o");
+      stems.add(base + "a");
+    }
+  }
+
+  // Try stripping verb tense endings (-as, -is, -os, -us)
+  for (const ending of VERB_TENSE_ENDINGS) {
+    if (lower.endsWith(ending) && lower.length > ending.length + 2) {
+      const root = lower.slice(0, -ending.length);
+      stems.add(root + "i"); // infinitive
+      stems.add(root);
+    }
+  }
+
+  // Try stripping short endings (-o, -a, -e, -i, -u, -n, -j)
+  for (const ending of SHORT_ENDINGS) {
+    if (lower.endsWith(ending) && lower.length > ending.length + 2) {
+      const base = lower.slice(0, -ending.length);
+      stems.add(base);
+      // For -n (accusative), also try the form without -n
+      if (ending === "n") {
+        stems.add(base + "o");
+        stems.add(base + "a");
+      }
+    }
+  }
+
+  // Sort: shortest stems first (most stripped), original last
+  return Array.from(stems).sort((a, b) => a.length - b.length);
+}
+
+/**
+ * Normalize a query for search: lowercase, convert x-system, trim.
+ */
+export function normalizeQuery(query: string): string {
+  let normalized = query.trim();
+  if (hasXSystem(normalized)) {
+    normalized = fromXSystem(normalized);
+  }
+  return normalized.toLowerCase();
+}

--- a/revo-mcp/src/tools/languages.ts
+++ b/revo-mcp/src/tools/languages.ts
@@ -1,0 +1,24 @@
+/**
+ * MCP tool: languages — List available languages in the Revo dictionary.
+ */
+
+import { getLanguages } from "../db";
+import { languageName } from "../formatter";
+
+export function handleLanguages(): string {
+  const languages = getLanguages();
+
+  const lines: string[] = [
+    `## Available Languages (${languages.length} total)`,
+    "",
+    "| Code | Language | Translations |",
+    "|------|----------|-------------|",
+  ];
+
+  for (const { lng, count } of languages) {
+    const name = languageName(lng);
+    lines.push(`| ${lng} | ${name} | ${count.toLocaleString()} |`);
+  }
+
+  return lines.join("\n");
+}

--- a/revo-mcp/src/tools/lookup.ts
+++ b/revo-mcp/src/tools/lookup.ts
@@ -1,0 +1,64 @@
+/**
+ * MCP tool: lookup — Search the Reta Vortaro (Esperanto dictionary).
+ */
+
+import { z } from "zod";
+import {
+  lookupEsperanto,
+  lookupTranslation,
+  lookupAllLanguages,
+} from "../db";
+import { formatResults } from "../formatter";
+import { hasXSystem, fromXSystem } from "../stemmer";
+
+export const lookupInputSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe("The word or phrase to look up"),
+  lang: z
+    .string()
+    .default("eo")
+    .describe(
+      "Language to search in. Use 'eo' for Esperanto headwords (default), " +
+      "'en'/'de'/'fr'/etc. for translation lookups, or 'all' to search across all languages."
+    ),
+  show_languages: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Which translation languages to show in results (e.g. ['en', 'de']). " +
+      "If omitted, shows a default set (en, de, fr, es, ru, zh, ja)."
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .default(5)
+    .describe("Maximum number of results to return (1-20)"),
+});
+
+export type LookupInput = z.infer<typeof lookupInputSchema>;
+
+export function handleLookup(args: LookupInput): string {
+  let { query, lang, show_languages, limit } = args;
+
+  // Convert x-system if present
+  if (hasXSystem(query)) {
+    query = fromXSystem(query);
+  }
+
+  let results;
+
+  if (lang === "eo") {
+    results = lookupEsperanto(query, limit);
+  } else if (lang === "all") {
+    results = lookupAllLanguages(query, limit);
+  } else {
+    results = lookupTranslation(query, lang, limit);
+  }
+
+  return formatResults(results, show_languages);
+}

--- a/revo-mcp/test/html-extract.test.ts
+++ b/revo-mcp/test/html-extract.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { Database } from "bun:sqlite";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { extractArticle, extractByMrk } from "../src/html-extract";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DB_PATH = join(__dirname, "..", "data", "revo.db");
+
+let db: Database;
+
+beforeAll(() => {
+  db = new Database(DB_PATH, { readonly: true });
+});
+
+function getArticleHtml(art: string): Buffer {
+  const row = db.query<{ txt: Buffer }, [string]>(
+    "SELECT txt FROM artikolo WHERE mrk = ?"
+  ).get(art);
+  if (!row) throw new Error(`Article not found: ${art}`);
+  return Buffer.from(row.txt);
+}
+
+describe("extractArticle", () => {
+  test("extracts all derivations from amik article", () => {
+    const html = getArticleHtml("amik");
+    const entries = extractArticle(html);
+
+    expect(entries.length).toBeGreaterThan(5);
+
+    const amiko = entries.find((e) => e.mrk === "amik.0o");
+    expect(amiko).toBeDefined();
+    expect(amiko!.headword).toContain("amiko");
+    expect(amiko!.senses.length).toBe(2); // Two numbered senses
+
+    const malamiko = entries.find((e) => e.mrk === "amik.mal0o");
+    expect(malamiko).toBeDefined();
+    expect(malamiko!.headword).toContain("malamiko");
+  });
+
+  test("extracts definitions from hund article", () => {
+    const html = getArticleHtml("hund");
+    const entries = extractArticle(html);
+
+    const hundo = entries.find((e) => e.mrk === "hund.0o");
+    expect(hundo).toBeDefined();
+    expect(hundo!.senses.length).toBe(3); // genro, dombesto, FIG
+
+    // First sense should mention "genro"
+    expect(hundo!.senses[0].definition).toContain("genro");
+    // Second sense should be about domestic dog
+    expect(hundo!.senses[1].definition).toContain("Dombesto");
+    // Third sense should be figurative
+    expect(hundo!.senses[2].definition).toContain("Insultvorto");
+  });
+
+  test("extracts examples from definitions", () => {
+    const html = getArticleHtml("hund");
+    const entries = extractArticle(html);
+    const hundo = entries.find((e) => e.mrk === "hund.0o");
+
+    // Second sense (dombesto) should have examples
+    const dombesto = hundo!.senses[1];
+    expect(dombesto.examples.length).toBeGreaterThan(3);
+    expect(dombesto.examples[0]).toContain("hund");
+  });
+
+  test("does not include translation language headings as senses", () => {
+    const html = getArticleHtml("amik");
+    const entries = extractArticle(html);
+    const amiko = entries.find((e) => e.mrk === "amik.0o");
+
+    // Should only have 2 real senses, not 100+ (which would include language headings)
+    expect(amiko!.senses.length).toBeLessThan(10);
+
+    // No sense should have a language name as its num
+    for (const sense of amiko!.senses) {
+      if (sense.num) {
+        expect(sense.num).not.toContain("angle");
+        expect(sense.num).not.toContain("germane");
+        expect(sense.num).not.toContain("france");
+      }
+    }
+  });
+
+  test("extracts single-sense articles correctly", () => {
+    const html = getArticleHtml("hund");
+    const entries = extractArticle(html);
+    const hundido = entries.find((e) => e.mrk === "hund.0ido");
+
+    expect(hundido).toBeDefined();
+    expect(hundido!.senses.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("extractByMrk", () => {
+  test("extracts a specific derivation by mrk", () => {
+    const html = getArticleHtml("amik");
+    const entry = extractByMrk(html, "amik.0o");
+
+    expect(entry).not.toBeNull();
+    expect(entry!.headword).toContain("amiko");
+    expect(entry!.senses.length).toBe(2);
+  });
+
+  test("extracts a specific sense by mrk", () => {
+    const html = getArticleHtml("hund");
+    const entry = extractByMrk(html, "hund.0o.dombesto");
+
+    expect(entry).not.toBeNull();
+    expect(entry!.senses.length).toBe(1);
+    expect(entry!.senses[0].definition).toContain("Dombesto");
+  });
+
+  test("returns null for non-existent mrk", () => {
+    const html = getArticleHtml("amik");
+    const entry = extractByMrk(html, "nonexistent.0o");
+    expect(entry).toBeNull();
+  });
+
+  test("handles article with no numbered senses", () => {
+    const html = getArticleHtml("hund");
+    const entry = extractByMrk(html, "hund.0ido");
+
+    expect(entry).not.toBeNull();
+    expect(entry!.senses.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/revo-mcp/test/lookup.test.ts
+++ b/revo-mcp/test/lookup.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, afterAll } from "bun:test";
+import {
+  lookupEsperanto,
+  lookupTranslation,
+  lookupAllLanguages,
+  getLanguages,
+  closeDb,
+} from "../src/db";
+
+afterAll(() => closeDb());
+
+describe("lookupEsperanto", () => {
+  test("finds exact headword 'amiko'", () => {
+    const results = lookupEsperanto("amiko", 1);
+    expect(results.length).toBe(1);
+    expect(results[0].headword).toBe("amiko");
+    expect(results[0].senses.length).toBeGreaterThan(0);
+  });
+
+  test("finds 'hundo' with multiple senses", () => {
+    const results = lookupEsperanto("hundo", 1);
+    expect(results.length).toBe(1);
+    expect(results[0].headword).toBe("hundo");
+    expect(results[0].senses.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("finds words with Esperanto characters", () => {
+    const results = lookupEsperanto("ĉirkaŭ", 1);
+    expect(results.length).toBe(1);
+    expect(results[0].headword).toContain("ĉirkaŭ");
+  });
+
+  test("returns translations for results", () => {
+    const results = lookupEsperanto("amiko", 1);
+    expect(results[0].translations.length).toBeGreaterThan(0);
+    const enTrd = results[0].translations.find((t) => t.lng === "en");
+    expect(enTrd).toBeDefined();
+    expect(enTrd!.trd).toBe("friend");
+  });
+});
+
+describe("lookupTranslation", () => {
+  test("finds 'friend' in English", () => {
+    const results = lookupTranslation("friend", "en", 2);
+    expect(results.length).toBeGreaterThan(0);
+    const amiko = results.find((r) => r.headword === "amiko");
+    expect(amiko).toBeDefined();
+  });
+
+  test("finds 'Hund' in German", () => {
+    const results = lookupTranslation("Hund", "de", 1);
+    expect(results.length).toBe(1);
+    expect(results[0].headword).toBe("hundo");
+  });
+
+  test("finds 'chien' in French", () => {
+    const results = lookupTranslation("chien", "fr", 5);
+    expect(results.length).toBeGreaterThan(0);
+    // 'chien' maps to hundo but may also match other entries (e.g., kolĉiko)
+    const hundo = results.find((r) => r.headword === "hundo");
+    expect(hundo).toBeDefined();
+  });
+
+  test("returns empty for non-existent translation", () => {
+    const results = lookupTranslation("xyzzy", "en", 5);
+    expect(results.length).toBe(0);
+  });
+});
+
+describe("lookupAllLanguages", () => {
+  test("finds 'Hund' across all languages (German)", () => {
+    const results = lookupAllLanguages("Hund", 3);
+    expect(results.length).toBeGreaterThan(0);
+    const hundo = results.find((r) => r.headword === "hundo");
+    expect(hundo).toBeDefined();
+  });
+});
+
+describe("getLanguages", () => {
+  test("returns list of languages", () => {
+    const langs = getLanguages();
+    expect(langs.length).toBeGreaterThan(100);
+
+    const en = langs.find((l) => l.lng === "en");
+    expect(en).toBeDefined();
+    expect(en!.count).toBeGreaterThan(10000);
+  });
+});

--- a/revo-mcp/test/mcp-server.test.ts
+++ b/revo-mcp/test/mcp-server.test.ts
@@ -1,0 +1,344 @@
+/**
+ * MCP protocol-level tests for the Revo dictionary server.
+ *
+ * Uses the SDK's InMemoryTransport to create an in-process client-server pair,
+ * then exercises the actual MCP protocol: listTools, callTool, etc.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { z } from "zod";
+import { lookupInputSchema, handleLookup } from "../src/tools/lookup";
+import { handleLanguages } from "../src/tools/languages";
+import { closeDb } from "../src/db";
+
+let client: Client;
+let server: McpServer;
+let clientTransport: InMemoryTransport;
+let serverTransport: InMemoryTransport;
+
+beforeAll(async () => {
+  // Create server with the same tools as index.ts
+  server = new McpServer({
+    name: "revo-vortaro-test",
+    version: "1.0.0",
+  });
+
+  server.tool(
+    "lookup",
+    "Look up a word in the Reta Vortaro (Esperanto dictionary).",
+    lookupInputSchema.shape,
+    async (args) => {
+      try {
+        const text = handleLookup(args as any);
+        return { content: [{ type: "text" as const, text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    "languages",
+    "List all available languages in the Reta Vortaro dictionary with their translation counts.",
+    {},
+    async () => {
+      try {
+        const text = handleLanguages();
+        return { content: [{ type: "text" as const, text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Create linked in-memory transport pair
+  [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  // Connect both sides
+  client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+});
+
+afterAll(async () => {
+  await client.close();
+  await server.close();
+  closeDb();
+});
+
+// ============================================================
+// Protocol-level discovery tests
+// ============================================================
+
+describe("MCP Protocol: Tool Discovery", () => {
+  test("lists available tools", async () => {
+    const result = await client.listTools();
+    expect(result.tools).toBeDefined();
+    expect(result.tools.length).toBe(2);
+
+    const toolNames = result.tools.map((t) => t.name);
+    expect(toolNames).toContain("lookup");
+    expect(toolNames).toContain("languages");
+  });
+
+  test("lookup tool has correct schema", async () => {
+    const result = await client.listTools();
+    const lookup = result.tools.find((t) => t.name === "lookup");
+    expect(lookup).toBeDefined();
+    expect(lookup!.description).toContain("Reta Vortaro");
+    expect(lookup!.inputSchema).toBeDefined();
+
+    // Verify schema has expected properties
+    const props = (lookup!.inputSchema as any).properties;
+    expect(props.query).toBeDefined();
+    expect(props.lang).toBeDefined();
+    expect(props.limit).toBeDefined();
+    expect(props.show_languages).toBeDefined();
+  });
+
+  test("languages tool has empty schema", async () => {
+    const result = await client.listTools();
+    const languages = result.tools.find((t) => t.name === "languages");
+    expect(languages).toBeDefined();
+    expect(languages!.description).toContain("languages");
+  });
+});
+
+// ============================================================
+// Protocol-level tool execution tests
+// ============================================================
+
+describe("MCP Protocol: callTool — Esperanto headword lookup", () => {
+  test("looks up 'amiko' via MCP protocol", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "amiko", lang: "eo", limit: 1 },
+    });
+
+    expect(result.content).toBeDefined();
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content.length).toBeGreaterThan(0);
+
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("amiko");
+    expect(text).toContain("Definitions");
+    expect(text).toContain("friend");
+    expect(text).toContain("Translations");
+  });
+
+  test("looks up 'hundo' with multiple senses", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "hundo", lang: "eo", limit: 1 },
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("hundo");
+    expect(text).toContain("1.");
+    expect(text).toContain("2.");
+    expect(text).toContain("3.");
+    expect(text).toContain("dog");
+  });
+
+  test("handles x-system input via protocol", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "cxirkaux", lang: "eo", limit: 1 },
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("ĉirkaŭ");
+  });
+
+  test("handles stemmed forms via protocol", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "amikojn", lang: "eo", limit: 1 },
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("amiko");
+    expect(text).toContain("stem:");
+  });
+});
+
+describe("MCP Protocol: callTool — Translation lookup", () => {
+  test("looks up 'friend' in English via MCP", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "friend", lang: "en", limit: 2 },
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("amiko");
+    expect(text).toContain("translation:en:friend");
+  });
+
+  test("looks up 'Hund' in German via MCP", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "Hund", lang: "de", limit: 1 },
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("hundo");
+  });
+
+  test("cross-language search via MCP", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "Hund", lang: "all", limit: 3 },
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("hundo");
+  });
+});
+
+describe("MCP Protocol: callTool — show_languages filtering", () => {
+  test("filters translations to specific languages", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: {
+        query: "amiko",
+        lang: "eo",
+        limit: 1,
+        show_languages: ["de", "en"],
+      },
+    });
+
+    const text = (result.content[0] as any).text;
+    // Should contain German and English
+    expect(text).toContain("Germana");
+    expect(text).toContain("Angla");
+    // Should NOT contain French, Spanish, etc.
+    expect(text).not.toContain("Franca");
+    expect(text).not.toContain("Hispana");
+  });
+});
+
+describe("MCP Protocol: callTool — languages tool", () => {
+  test("lists languages via MCP protocol", async () => {
+    const result = await client.callTool({
+      name: "languages",
+      arguments: {},
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("Available Languages");
+    expect(text).toContain("174");
+    expect(text).toContain("en");
+    expect(text).toContain("de");
+    expect(text).toContain("Angla");
+    expect(text).toContain("Germana");
+  });
+});
+
+describe("MCP Protocol: callTool — edge cases", () => {
+  test("non-existent word returns no results", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "xyzzy", lang: "eo", limit: 5 },
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toBe("No results found.");
+    expect(result.isError).toBeFalsy();
+  });
+
+  test("empty query returns no results", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: " ", lang: "eo", limit: 1 },
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toBe("No results found.");
+  });
+
+  test("default parameters work correctly", async () => {
+    // Only required param is query — lang defaults to "eo", limit to 5
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "amiko" },
+    });
+
+    const text = (result.content[0] as any).text;
+    expect(text).toContain("amiko");
+    expect(text).toContain("Definitions");
+  });
+
+  test("multiple results returned correctly", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "friend", lang: "en", limit: 3 },
+    });
+
+    const text = (result.content[0] as any).text;
+    // Should return multiple results separated by ---
+    expect(typeof text).toBe("string");
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain("amiko");
+  });
+});
+
+// ============================================================
+// Protocol-level response format validation
+// ============================================================
+
+describe("MCP Protocol: Response format validation", () => {
+  test("lookup returns proper CallToolResult structure", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "amiko", lang: "eo", limit: 1 },
+    });
+
+    // Validate response structure
+    expect(result).toHaveProperty("content");
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content.length).toBeGreaterThan(0);
+
+    const item = result.content[0] as any;
+    expect(item.type).toBe("text");
+    expect(typeof item.text).toBe("string");
+  });
+
+  test("languages returns proper CallToolResult structure", async () => {
+    const result = await client.callTool({
+      name: "languages",
+      arguments: {},
+    });
+
+    expect(result).toHaveProperty("content");
+    expect(result.content.length).toBeGreaterThan(0);
+
+    const item = result.content[0] as any;
+    expect(item.type).toBe("text");
+    expect(typeof item.text).toBe("string");
+  });
+
+  test("result text is valid markdown", async () => {
+    const result = await client.callTool({
+      name: "lookup",
+      arguments: { query: "amiko", lang: "eo", limit: 1 },
+    });
+
+    const text = (result.content[0] as any).text as string;
+    // Should contain markdown headers
+    expect(text).toContain("## ");
+    expect(text).toContain("### ");
+    // Should contain markdown bold
+    expect(text).toContain("**");
+  });
+});

--- a/revo-mcp/test/scenarios.test.ts
+++ b/revo-mcp/test/scenarios.test.ts
@@ -1,0 +1,698 @@
+/**
+ * 100 Usage Scenarios for the Revo MCP Server.
+ *
+ * These represent real-world queries from:
+ * - Beginner Esperanto learners (from English, German, French, etc.)
+ * - Intermediate learners encountering new words
+ * - Native/fluent speakers looking up precise definitions
+ * - Various edge cases and error handling
+ *
+ * Each scenario tests the handleLookup function end-to-end.
+ */
+
+import { describe, test, expect, afterAll } from "bun:test";
+import { handleLookup } from "../src/tools/lookup";
+import { closeDb } from "../src/db";
+
+afterAll(() => closeDb());
+
+// Helper: check result contains expected content
+function expectResultContains(
+  result: string,
+  ...fragments: string[]
+): void {
+  for (const frag of fragments) {
+    expect(result.toLowerCase()).toContain(frag.toLowerCase());
+  }
+}
+
+function expectHasResults(result: string): void {
+  expect(result).not.toBe("No results found.");
+}
+
+// ============================================================
+// A. Beginner Esperanto Learner (English native) — 15 scenarios
+// ============================================================
+
+describe("A. Beginner (English native)", () => {
+  test("1. Look up 'hello' in English", () => {
+    const r = handleLookup({ query: "hello", lang: "en", limit: 5 });
+    expectHasResults(r);
+    expectResultContains(r, "salut");
+  });
+
+  test("2. Look up 'thank you' in English", () => {
+    // "thank" is more likely to be found
+    const r = handleLookup({ query: "thank", lang: "en", limit: 5 });
+    expectHasResults(r);
+    expectResultContains(r, "dank");
+  });
+
+  test("3. Look up 'water' in English", () => {
+    const r = handleLookup({ query: "water", lang: "en", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "akvo");
+  });
+
+  test("4. Look up 'eat' in English", () => {
+    const r = handleLookup({ query: "eat", lang: "en", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "manĝ");
+  });
+
+  test("5. Look up 'house' in English", () => {
+    const r = handleLookup({ query: "house", lang: "en", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "dom");
+  });
+
+  test("6. Look up 'amiko' in Esperanto — see definition + translation", () => {
+    const r = handleLookup({ query: "amiko", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "amiko", "friend");
+    // Should have Esperanto definition
+    expect(r).toContain("Definitions");
+  });
+
+  test("7. Look up 'granda' in Esperanto", () => {
+    const r = handleLookup({ query: "granda", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "granda");
+  });
+
+  test("8. Look up 'run' in English", () => {
+    const r = handleLookup({ query: "run", lang: "en", limit: 5 });
+    expectHasResults(r);
+    expectResultContains(r, "kur");
+  });
+
+  test("9. Look up 'beautiful' in English", () => {
+    const r = handleLookup({ query: "beautiful", lang: "en", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "bel");
+  });
+
+  test("10. Look up 'book' in English", () => {
+    const r = handleLookup({ query: "book", lang: "en", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "libr");
+  });
+
+  test("11. Look up 'cat' in English", () => {
+    const r = handleLookup({ query: "cat", lang: "en", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "kato");
+  });
+
+  test("12. Look up 'love' in English", () => {
+    const r = handleLookup({ query: "love", lang: "en", limit: 5 });
+    expectHasResults(r);
+    expectResultContains(r, "am");
+  });
+
+  test("13. Look up 'tree' in English", () => {
+    const r = handleLookup({ query: "tree", lang: "en", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "arbo");
+  });
+
+  test("14. Look up 'red' in English", () => {
+    const r = handleLookup({ query: "red", lang: "en", limit: 5 });
+    expectHasResults(r);
+    expectResultContains(r, "ruĝ");
+  });
+
+  test("15. Look up 'child' in English", () => {
+    const r = handleLookup({ query: "child", lang: "en", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "infan");
+  });
+});
+
+// ============================================================
+// B. Beginner Esperanto Learner (German native) — 10 scenarios
+// ============================================================
+
+describe("B. Beginner (German native)", () => {
+  test("16. Look up 'Freund' in German", () => {
+    const r = handleLookup({ query: "Freund", lang: "de", limit: 2 });
+    expectHasResults(r);
+    expectResultContains(r, "amiko");
+  });
+
+  test("17. Look up 'Hund' in German", () => {
+    const r = handleLookup({ query: "Hund", lang: "de", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "hundo");
+  });
+
+  test("18. Look up 'Katze' in German", () => {
+    const r = handleLookup({ query: "Katze", lang: "de", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "kato");
+  });
+
+  test("19. Look up 'Haus' in German", () => {
+    const r = handleLookup({ query: "Haus", lang: "de", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "dom");
+  });
+
+  test("20. Look up 'Wasser' in German", () => {
+    const r = handleLookup({ query: "Wasser", lang: "de", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "akvo");
+  });
+
+  test("21. Look up 'schön' in German", () => {
+    const r = handleLookup({ query: "schön", lang: "de", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "bel");
+  });
+
+  test("22. Look up 'essen' in German", () => {
+    const r = handleLookup({ query: "essen", lang: "de", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "manĝ");
+  });
+
+  test("23. Look up 'Buch' in German", () => {
+    const r = handleLookup({ query: "Buch", lang: "de", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "libr");
+  });
+
+  test("24. Look up 'Baum' in German", () => {
+    const r = handleLookup({ query: "Baum", lang: "de", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "arb");
+  });
+
+  test("25. Look up 'Freundin' in German", () => {
+    const r = handleLookup({ query: "Freundin", lang: "de", limit: 2 });
+    expectHasResults(r);
+    expectResultContains(r, "amik");
+  });
+});
+
+// ============================================================
+// C. Beginner from French — 5 scenarios
+// ============================================================
+
+describe("C. Beginner (French native)", () => {
+  test("26. Look up 'ami' in French", () => {
+    const r = handleLookup({ query: "ami", lang: "fr", limit: 2 });
+    expectHasResults(r);
+    expectResultContains(r, "amiko");
+  });
+
+  test("27. Look up 'chien' in French", () => {
+    const r = handleLookup({ query: "chien", lang: "fr", limit: 5 });
+    expectHasResults(r);
+    // 'chien' appears in translations for both hundo and kolĉiko
+    expectResultContains(r, "hundo");
+  });
+
+  test("28. Look up 'maison' in French", () => {
+    const r = handleLookup({ query: "maison", lang: "fr", limit: 2 });
+    expectHasResults(r);
+    expectResultContains(r, "dom");
+  });
+
+  test("29. Look up 'manger' in French", () => {
+    const r = handleLookup({ query: "manger", lang: "fr", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "manĝ");
+  });
+
+  test("30. Look up 'chat' in French", () => {
+    const r = handleLookup({ query: "chat", lang: "fr", limit: 2 });
+    expectHasResults(r);
+    expectResultContains(r, "kato");
+  });
+});
+
+// ============================================================
+// D. Esperanto Word Lookups (exact headword) — 15 scenarios
+// ============================================================
+
+describe("D. Esperanto headword lookups", () => {
+  test("31. 'amiko' — full entry", () => {
+    const r = handleLookup({ query: "amiko", lang: "eo", limit: 1 });
+    expectResultContains(r, "amiko", "Definitions", "Translations");
+  });
+
+  test("32. 'hundo' — multiple senses", () => {
+    const r = handleLookup({ query: "hundo", lang: "eo", limit: 1 });
+    expectResultContains(r, "hundo", "1.", "2.", "3.");
+  });
+
+  test("33. 'esti' — fundamental verb", () => {
+    const r = handleLookup({ query: "esti", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "esti");
+  });
+
+  test("34. 'la' — article", () => {
+    const r = handleLookup({ query: "la", lang: "eo", limit: 1 });
+    expectHasResults(r);
+  });
+
+  test("35. 'kaj' — conjunction", () => {
+    const r = handleLookup({ query: "kaj", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "kaj");
+  });
+
+  test("36. 'tre' — adverb", () => {
+    const r = handleLookup({ query: "tre", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "tre");
+  });
+
+  test("37. 'ĉirkaŭ' — word with ĉ", () => {
+    const r = handleLookup({ query: "ĉirkaŭ", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ĉirkaŭ");
+  });
+
+  test("38. 'ĝardeno' — word with ĝ", () => {
+    const r = handleLookup({ query: "ĝardeno", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ĝardeno");
+  });
+
+  test("39. 'ŝipo' — word with ŝ", () => {
+    const r = handleLookup({ query: "ŝipo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ŝipo");
+  });
+
+  test("40. 'ĵaŭdo' — word with ĵ", () => {
+    const r = handleLookup({ query: "ĵaŭdo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ĵaŭdo");
+  });
+
+  test("41. 'ĥoro' — word with rare ĥ", () => {
+    const r = handleLookup({ query: "ĥoro", lang: "eo", limit: 1 });
+    expectHasResults(r);
+  });
+
+  test("42. 'aŭskulti' — word with ŭ", () => {
+    const r = handleLookup({ query: "aŭskulti", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "aŭskulti");
+  });
+
+  test("43. 'malgranda' — compound with mal-", () => {
+    const r = handleLookup({ query: "malgranda", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "malgranda");
+  });
+
+  test("44. 'gepatroj' — compound with ge-", () => {
+    const r = handleLookup({ query: "gepatroj", lang: "eo", limit: 1 });
+    expectHasResults(r);
+  });
+
+  test("45. 'lernejo' — compound with -ej suffix", () => {
+    const r = handleLookup({ query: "lernejo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "lernejo");
+  });
+});
+
+// ============================================================
+// E. X-System Input — 8 scenarios
+// ============================================================
+
+describe("E. X-System Input", () => {
+  test("46. 'cxirkaux' → ĉirkaŭ", () => {
+    const r = handleLookup({ query: "cxirkaux", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ĉirkaŭ");
+  });
+
+  test("47. 'gxardeno' → ĝardeno", () => {
+    const r = handleLookup({ query: "gxardeno", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ĝardeno");
+  });
+
+  test("48. 'sxipo' → ŝipo", () => {
+    const r = handleLookup({ query: "sxipo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ŝipo");
+  });
+
+  test("49. 'jxauxdo' → ĵaŭdo", () => {
+    const r = handleLookup({ query: "jxauxdo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ĵaŭdo");
+  });
+
+  test("50. 'hxoro' → ĥoro", () => {
+    const r = handleLookup({ query: "hxoro", lang: "eo", limit: 1 });
+    expectHasResults(r);
+  });
+
+  test("51. 'auxskulti' → aŭskulti", () => {
+    const r = handleLookup({ query: "auxskulti", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "aŭskulti");
+  });
+
+  test("52. 'Cxu' → ĉu (case-insensitive)", () => {
+    const r = handleLookup({ query: "Cxu", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ĉu");
+  });
+
+  test("53. 'mangxi' → manĝi", () => {
+    const r = handleLookup({ query: "mangxi", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "manĝi");
+  });
+});
+
+// ============================================================
+// F. Grammatical Form Stemming — 12 scenarios
+// ============================================================
+
+describe("F. Grammatical form stemming", () => {
+  test("54. 'amikojn' (pl. acc.) → amiko", () => {
+    const r = handleLookup({ query: "amikojn", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "amiko");
+  });
+
+  test("55. 'amikon' (acc.) → amiko", () => {
+    const r = handleLookup({ query: "amikon", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "amiko");
+  });
+
+  test("56. 'amikoj' (pl.) → amiko", () => {
+    const r = handleLookup({ query: "amikoj", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "amiko");
+  });
+
+  test("57. 'grandaj' (pl. adj.) → granda", () => {
+    const r = handleLookup({ query: "grandaj", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "granda");
+  });
+
+  test("58. 'grandan' (acc. adj.) → granda", () => {
+    const r = handleLookup({ query: "grandan", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "granda");
+  });
+
+  test("59. 'manĝas' (present) → manĝi", () => {
+    const r = handleLookup({ query: "manĝas", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "manĝi");
+  });
+
+  test("60. 'manĝis' (past) → manĝi", () => {
+    const r = handleLookup({ query: "manĝis", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "manĝi");
+  });
+
+  test("61. 'manĝos' (future) → manĝi", () => {
+    const r = handleLookup({ query: "manĝos", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "manĝi");
+  });
+
+  test("62. 'manĝus' (conditional) → manĝi", () => {
+    const r = handleLookup({ query: "manĝus", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "manĝi");
+  });
+
+  test("63. 'manĝu' (imperative) → manĝi", () => {
+    const r = handleLookup({ query: "manĝu", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "manĝ");
+  });
+
+  test("64. 'rapide' (adverb) → rapida or rapide", () => {
+    const r = handleLookup({ query: "rapide", lang: "eo", limit: 2 });
+    expectHasResults(r);
+    expectResultContains(r, "rapid");
+  });
+
+  test("65. 'homojn' → homo", () => {
+    const r = handleLookup({ query: "homojn", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "homo");
+  });
+});
+
+// ============================================================
+// G. Compound and Derived Words — 8 scenarios
+// ============================================================
+
+describe("G. Compound and derived words", () => {
+  test("66. 'malamiko' — enemy (mal+amik)", () => {
+    const r = handleLookup({ query: "malamiko", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "malamiko");
+  });
+
+  test("67. 'amikino' — female friend", () => {
+    const r = handleLookup({ query: "amikino", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "amikino");
+  });
+
+  test("68. 'amikeco' — friendship", () => {
+    const r = handleLookup({ query: "amikeco", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "amikeco");
+  });
+
+  test("69. 'hundejo' — kennel (hund+ej)", () => {
+    const r = handleLookup({ query: "hundejo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "hundejo");
+  });
+
+  test("70. 'hundido' — puppy (hund+id)", () => {
+    const r = handleLookup({ query: "hundido", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "hundido");
+  });
+
+  test("71. 'lernanto' — student (lern+ant)", () => {
+    const r = handleLookup({ query: "lernanto", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "lernanto");
+  });
+
+  test("72. 'instruisto' — teacher (instru+ist)", () => {
+    const r = handleLookup({ query: "instruisto", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "instruisto");
+  });
+
+  test("73. 'ĉashundo' — hunting dog", () => {
+    const r = handleLookup({ query: "ĉashundo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "ĉashundo");
+  });
+});
+
+// ============================================================
+// H. Multi-Sense Words and Disambiguation — 8 scenarios
+// ============================================================
+
+describe("H. Multi-sense words", () => {
+  test("74. 'abako' — multiple senses", () => {
+    const r = handleLookup({ query: "abako", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expect(r).toContain("Definitions");
+  });
+
+  test("75. 'krono' — crown (multiple meanings)", () => {
+    const r = handleLookup({ query: "krono", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "krono");
+  });
+
+  test("76. 'hundo' — genus, domestic, figurative", () => {
+    const r = handleLookup({ query: "hundo", lang: "eo", limit: 1 });
+    expectResultContains(r, "1.", "2.", "3.");
+  });
+
+  test("77. 'radioj' stemming → radio", () => {
+    const r = handleLookup({ query: "radioj", lang: "eo", limit: 2 });
+    expectHasResults(r);
+    expectResultContains(r, "radio");
+  });
+
+  test("78. 'noto' — note (multiple meanings)", () => {
+    const r = handleLookup({ query: "noto", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "noto");
+  });
+
+  test("79. 'parto' — part", () => {
+    const r = handleLookup({ query: "parto", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "parto");
+  });
+
+  test("80. 'muso' — mouse", () => {
+    const r = handleLookup({ query: "muso", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "muso");
+  });
+
+  test("81. 'pilko' — ball", () => {
+    const r = handleLookup({ query: "pilko", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "pilko");
+  });
+});
+
+// ============================================================
+// I. Cross-Language Search (lang=all) — 5 scenarios
+// ============================================================
+
+describe("I. Cross-language search", () => {
+  test("82. 'cat' across all languages", () => {
+    const r = handleLookup({ query: "cat", lang: "all", limit: 5 });
+    expectHasResults(r);
+  });
+
+  test("83. 'Hund' across all languages → hundo via German", () => {
+    const r = handleLookup({ query: "Hund", lang: "all", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "hundo");
+  });
+
+  test("84. 'ami' across all languages → amiko via French+", () => {
+    const r = handleLookup({ query: "ami", lang: "all", limit: 5 });
+    expectHasResults(r);
+    expectResultContains(r, "amik");
+  });
+
+  test("85. 'друг' across all languages → amiko via Russian", () => {
+    const r = handleLookup({ query: "друг", lang: "all", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "amik");
+  });
+
+  test("86. 'amigo' across all languages → amiko via Spanish/Portuguese", () => {
+    const r = handleLookup({ query: "amigo", lang: "all", limit: 3 });
+    expectHasResults(r);
+    expectResultContains(r, "amik");
+  });
+});
+
+// ============================================================
+// J. Specialized/Domain Lookups — 5 scenarios
+// ============================================================
+
+describe("J. Specialized/domain lookups", () => {
+  test("87. 'absceso' — medical term", () => {
+    const r = handleLookup({ query: "absceso", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "absceso");
+  });
+
+  test("88. 'algoritmo' — computer science term", () => {
+    const r = handleLookup({ query: "algoritmo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "algoritmo");
+  });
+
+  test("89. 'fotosintezo' — biology term", () => {
+    const r = handleLookup({ query: "fotosintezo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "fotosintezo");
+  });
+
+  test("90. 'akuzativo' — grammar term", () => {
+    const r = handleLookup({ query: "akuzativo", lang: "eo", limit: 1 });
+    expectHasResults(r);
+    expectResultContains(r, "akuzativo");
+  });
+
+  test("91. 'fortepiano' — music term", () => {
+    const r = handleLookup({ query: "fortepiano", lang: "eo", limit: 1 });
+    expectHasResults(r);
+  });
+});
+
+// ============================================================
+// K. Latin Lookups — 3 scenarios
+// ============================================================
+
+describe("K. Latin lookups", () => {
+  test("92. 'Canis' in Latin → hundo", () => {
+    const r = handleLookup({ query: "Canis", lang: "la", limit: 3 });
+    expectHasResults(r);
+  });
+
+  test("93. 'Felis' in Latin → kato", () => {
+    const r = handleLookup({ query: "Felis", lang: "la", limit: 3 });
+    expectHasResults(r);
+  });
+
+  test("94. 'Homo' in Latin → homo", () => {
+    const r = handleLookup({ query: "Homo", lang: "la", limit: 3 });
+    expectHasResults(r);
+  });
+});
+
+// ============================================================
+// L. Edge Cases and Error Handling — 6 scenarios
+// ============================================================
+
+describe("L. Edge cases", () => {
+  test("95. Empty/whitespace query → no results", () => {
+    const r = handleLookup({ query: " ", lang: "eo", limit: 1 });
+    expect(r).toBe("No results found.");
+  });
+
+  test("96. Very long query → handled", () => {
+    const longQuery = "a".repeat(100);
+    const r = handleLookup({ query: longQuery, lang: "eo", limit: 1 });
+    // Should return no results but not crash
+    expect(r).toBe("No results found.");
+  });
+
+  test("97. Special characters → safe, no injection", () => {
+    const r = handleLookup({
+      query: '<script>alert(1)</script>',
+      lang: "eo",
+      limit: 1,
+    });
+    // Should not crash, should return no results
+    expect(r).toBe("No results found.");
+  });
+
+  test("98. Non-existent word → no results", () => {
+    const r = handleLookup({ query: "xyzzy", lang: "eo", limit: 5 });
+    expect(r).toBe("No results found.");
+  });
+
+  test("99. Single letter 'a'", () => {
+    const r = handleLookup({ query: "a", lang: "eo", limit: 3 });
+    // Should find something — the article "a" exists
+    expectHasResults(r);
+  });
+
+  test("100. Numbers and mixed input", () => {
+    const r = handleLookup({ query: "123abc", lang: "eo", limit: 1 });
+    // Should not crash
+    expect(typeof r).toBe("string");
+  });
+});

--- a/revo-mcp/test/stemmer.test.ts
+++ b/revo-mcp/test/stemmer.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect } from "bun:test";
+import {
+  fromXSystem,
+  hasXSystem,
+  generateStems,
+  normalizeQuery,
+} from "../src/stemmer";
+
+describe("fromXSystem", () => {
+  test("converts lowercase x-system characters", () => {
+    expect(fromXSystem("cx")).toBe("ĉ");
+    expect(fromXSystem("gx")).toBe("ĝ");
+    expect(fromXSystem("hx")).toBe("ĥ");
+    expect(fromXSystem("jx")).toBe("ĵ");
+    expect(fromXSystem("sx")).toBe("ŝ");
+    expect(fromXSystem("ux")).toBe("ŭ");
+  });
+
+  test("converts uppercase x-system characters", () => {
+    expect(fromXSystem("Cx")).toBe("Ĉ");
+    expect(fromXSystem("Gx")).toBe("Ĝ");
+    expect(fromXSystem("Sx")).toBe("Ŝ");
+  });
+
+  test("converts full words", () => {
+    expect(fromXSystem("cxirkaux")).toBe("ĉirkaŭ");
+    expect(fromXSystem("gxardeno")).toBe("ĝardeno");
+    expect(fromXSystem("sxipo")).toBe("ŝipo");
+    expect(fromXSystem("jxauxdo")).toBe("ĵaŭdo");
+    expect(fromXSystem("hxoro")).toBe("ĥoro");
+    expect(fromXSystem("auxskulti")).toBe("aŭskulti");
+  });
+
+  test("handles mixed text", () => {
+    expect(fromXSystem("Mi mangxas")).toBe("Mi manĝas");
+    expect(fromXSystem("Cxu vi parolas?")).toBe("Ĉu vi parolas?");
+  });
+
+  test("leaves non-x-system text unchanged", () => {
+    expect(fromXSystem("amiko")).toBe("amiko");
+    expect(fromXSystem("domo")).toBe("domo");
+    expect(fromXSystem("")).toBe("");
+  });
+
+  test("does not convert 'ex' or other non-Esperanto combinations", () => {
+    // 'ex' should NOT be converted since 'e' is not a valid x-system prefix
+    expect(fromXSystem("extra")).toBe("extra");
+  });
+});
+
+describe("hasXSystem", () => {
+  test("detects x-system notation", () => {
+    expect(hasXSystem("cxirkaux")).toBe(true);
+    expect(hasXSystem("mangxi")).toBe(true);
+    expect(hasXSystem("Cxu")).toBe(true);
+  });
+
+  test("returns false for plain text", () => {
+    expect(hasXSystem("amiko")).toBe(false);
+    expect(hasXSystem("ĉirkaŭ")).toBe(false);
+    expect(hasXSystem("hello")).toBe(false);
+  });
+});
+
+describe("generateStems", () => {
+  test("strips plural accusative -ojn", () => {
+    const stems = generateStems("amikojn");
+    expect(stems).toContain("amiko");
+    expect(stems).toContain("amik");
+  });
+
+  test("strips accusative -on", () => {
+    const stems = generateStems("amikon");
+    expect(stems).toContain("amiko");
+    expect(stems).toContain("amik");
+  });
+
+  test("strips plural -oj", () => {
+    const stems = generateStems("amikoj");
+    expect(stems).toContain("amiko");
+    expect(stems).toContain("amik");
+  });
+
+  test("strips adjective plural -aj", () => {
+    const stems = generateStems("grandaj");
+    expect(stems).toContain("granda");
+    expect(stems).toContain("grand");
+  });
+
+  test("strips verb present tense -as", () => {
+    const stems = generateStems("manĝas");
+    expect(stems).toContain("manĝi");
+    expect(stems).toContain("manĝ");
+  });
+
+  test("strips verb past tense -is", () => {
+    const stems = generateStems("manĝis");
+    expect(stems).toContain("manĝi");
+  });
+
+  test("strips verb future tense -os", () => {
+    const stems = generateStems("manĝos");
+    expect(stems).toContain("manĝi");
+  });
+
+  test("strips verb conditional -us", () => {
+    const stems = generateStems("manĝus");
+    expect(stems).toContain("manĝi");
+  });
+
+  test("strips verb imperative -u", () => {
+    const stems = generateStems("manĝu");
+    expect(stems).toContain("manĝ");
+  });
+
+  test("includes the original word", () => {
+    const stems = generateStems("amikojn");
+    expect(stems).toContain("amikojn");
+  });
+
+  test("returns stems sorted shortest first", () => {
+    const stems = generateStems("amikojn");
+    for (let i = 1; i < stems.length; i++) {
+      expect(stems[i].length).toBeGreaterThanOrEqual(stems[i - 1].length);
+    }
+  });
+
+  test("handles short words without crashing", () => {
+    const stems = generateStems("la");
+    expect(stems).toContain("la");
+    expect(stems.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("handles participial endings", () => {
+    const stems = generateStems("leganta");
+    expect(stems).toContain("legi");
+  });
+});
+
+describe("normalizeQuery", () => {
+  test("converts to lowercase", () => {
+    expect(normalizeQuery("Amiko")).toBe("amiko");
+  });
+
+  test("trims whitespace", () => {
+    expect(normalizeQuery("  amiko  ")).toBe("amiko");
+  });
+
+  test("converts x-system and lowercases", () => {
+    expect(normalizeQuery("Cxirkaux")).toBe("ĉirkaŭ");
+  });
+
+  test("handles plain unicode Esperanto", () => {
+    expect(normalizeQuery("ĉirkaŭ")).toBe("ĉirkaŭ");
+  });
+});

--- a/revo-mcp/tsconfig.json
+++ b/revo-mcp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

This PR introduces a complete MCP (Model Context Protocol) server implementation for Reta Vortaro, the comprehensive open-source Esperanto dictionary. The server enables AI assistants like Claude to look up Esperanto words, translations across 174 languages, and provides definitions with examples.

## Key Changes

- **Database layer** (`src/db.ts`): Implements multi-strategy word lookup (exact match, variant match, stemmed forms, prefix search, FTS5 fallback) for both Esperanto headwords and translations across all languages
- **HTML extraction** (`src/html-extract.ts`): Parses machine-generated HTML article blobs from the SQLite database to extract structured definitions, examples, domains, and cross-references
- **Stemmer** (`src/stemmer.ts`): Handles Esperanto-specific text normalization including x-system conversion (cx→ĉ, gx→ĝ, etc.) and grammatical ending stripping to find dictionary headwords
- **Formatter** (`src/formatter.ts`): Converts lookup results to readable Markdown with language name mappings for 174+ languages
- **MCP tools** (`src/tools/lookup.ts`, `src/tools/languages.ts`): Implements two MCP tools—`lookup` for dictionary searches and `languages` for listing available translation languages
- **Server entry point** (`src/index.ts`): Stdio-based MCP server that integrates all components for use with Claude Desktop and CLI
- **Setup script** (`src/setup.ts`): Downloads the pre-built Revo SQLite database from GitHub releases and augments it with FTS5 indexes for fast full-text search
- **Comprehensive test suite**: 
  - `test/scenarios.test.ts`: 100 real-world usage scenarios covering beginner learners (English, German, French natives), Esperanto word lookups, x-system input, and edge cases
  - `test/mcp-server.test.ts`: Protocol-level MCP tests validating tool discovery and execution
  - `test/stemmer.test.ts`: Unit tests for x-system conversion and grammatical stemming
  - `test/html-extract.test.ts`: Tests for HTML parsing and definition extraction
  - `test/lookup.test.ts`: Tests for database query functions

## Notable Implementation Details

- **Multi-strategy lookup**: Tries exact match → variant match → stemmed forms → prefix search → FTS5 fallback to maximize hit rate across different query types
- **X-system support**: Transparently converts x-system notation (common for users without Esperanto keyboard layouts) to proper Unicode characters
- **Grammatical stemming**: Strips Esperanto grammatical endings (-ojn, -oj, -on, -an, -as, -is, -os, etc.) to find dictionary headwords from inflected forms
- **Language-aware translation search**: Filters translation lookups by language code while supporting both exact and fuzzy matching
- **Result enrichment**: Includes matched-via metadata to show users how results were found (exact, stem, prefix, FTS, translation)

https://claude.ai/code/session_01YLPQifd4e7FvUBeRF2UgX6